### PR TITLE
added missing third argument "this" to _.each

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@
 					// Compose dependencies
 					_.each(requires, function (require) {
 						depends.push("require(" + this.quote() + require + this.quote() + ")");
-					});
+					}, this);
 
 					return "// CommonJS\nmodule.exports = exports = " + this.factory() + "(" + depends.join(", ") + ");";
 				}


### PR DESCRIPTION
This was causing an error where the `quote` function was not found because `this` was global. The fix was to pass `this` to `_.each` as is done elsewhere in the file.